### PR TITLE
Update truffle-config.js

### DIFF
--- a/truffle-config.js
+++ b/truffle-config.js
@@ -2,7 +2,7 @@ module.exports = {
   networks: {
     development: {
       host: "127.0.0.1",
-      port: 7545,
+      port: 8545,
       network_id: "*"
     }
   },


### PR DESCRIPTION
Is there a reason why the app expects to connect to 7545? garnachi-cli open runs on 8545 by default